### PR TITLE
Reduce the transition time to minimize the animation delay.

### DIFF
--- a/less/carousel.less
+++ b/less/carousel.less
@@ -16,7 +16,7 @@
   > .item {
     display: none;
     position: relative;
-    .transition(.6s ease-in-out left);
+    .transition(.01s ease-in-out left);
 
     // Account for jankitude on images
     > img,


### PR DESCRIPTION
Power users prefer to minimize the delay of the animation. Please let me know if there is a better way to override this value rather than changing the bootstrap carousel configuration.

@ldevalliere 
